### PR TITLE
Have the option to have the slider behave like a (one-way)-carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,8 @@
     wSShowPreviousClass: 'wallop-slider__item--show-previous',
     wSShowNextClass: 'wallop-slider__item--show-next',
     wSHidePreviousClass: 'wallop-slider__item--hide-previous',
-    wSHideNextClass: 'wallop-slider__item--hide-next'
+    wSHideNextClass: 'wallop-slider__item--hide-next',
+    wsCarousel = false // Shall the last slide go to the first?
   });
 &lt;/script&gt;
       </code></pre>

--- a/scripts/WallopSlider.js
+++ b/scripts/WallopSlider.js
@@ -25,7 +25,8 @@ WallopSlider = (function() {
       wSShowPreviousClass: 'wallop-slider__item--show-previous',
       wSShowNextClass: 'wallop-slider__item--show-next',
       wSHidePreviousClass: 'wallop-slider__item--hide-previous',
-      wSHideNextClass: 'wallop-slider__item--hide-next'
+      wSHideNextClass: 'wallop-slider__item--hide-next',
+      wSCarousel: false
     };
 
     this.selector = selector;
@@ -50,7 +51,7 @@ WallopSlider = (function() {
 
   // Update prev/next disabled attribute
   WallopProto.updatePagination = function () {
-    if ((this.currentItemIndex + 1) === this.allItemsArrayLength) {
+    if ((this.currentItemIndex + 1) === this.allItemsArrayLength && this.options.wSCarousel !== true) {
       this.buttonNext.setAttribute('disabled');
     } else if (this.currentItemIndex === 0) {
       this.buttonPrevious.setAttribute('disabled');
@@ -94,7 +95,11 @@ WallopSlider = (function() {
 
   // Callback for when next button is clicked
   WallopProto.onNextButtonClicked = function () {
-    this.goTo((this.currentItemIndex + 1) + 1);
+    if(this.currentItemIndex + 1 === this.allItemsArrayLength && this.options.wSCarousel === true) {
+      this.goTo(1);
+    } else {
+      this.goTo((this.currentItemIndex + 1) + 1);
+    }
   };
 
   // Attach click handlers


### PR DESCRIPTION
- Added option „wSCarousel“
- updatePagination doesn’t remove the next-button on last-item if
  wSCarousel === true
- goTo goes to first slide if triggered on last-slide
- CSS-animations work along and give a nice visual feedback
