### PR TITLE
Fixed wSCarousel Option In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Let's say you want to go to the second slide when you click on your button.
 
 ```
 document.querySelector('.button').addEventListener('click', function () {
-  slider.toGo(2);
+  slider.goTo(2);
 });
 
 ```


### PR DESCRIPTION
By the way, you should update the website with the contents of the `site` folder. On the website, the option name is still wrong, but it is correct in the GitHub repo.

EDIT: fixed another typo (`goTo` instead of `toGo`)
