### PR TITLE
Make MIT license explict

### DIFF
--- a/COPYING.MIT
+++ b/COPYING.MIT
@@ -1,0 +1,19 @@
+Copyright 2013-2014 Pedro Duarte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -63,5 +63,11 @@ $('.button').click(function () {
 });
 ```
 
----
-Built by Pedro Duarte
+## Author and license
+
+WallopSlide has been built by Pedro Duarte.
+
+WallopSlide is free software released under the MIT licence.
+
+See the `COPYING.MIT` file or <http://opensource.org/licenses/MIT>
+for more details.

--- a/dist/WallopSlider.css
+++ b/dist/WallopSlider.css
@@ -1,3 +1,11 @@
+/*
+ * WallopSlide has been built by Pedro Duarte.
+ *
+ * WallopSlide is free software released under the MIT licence.
+ *
+ * See the `COPYING.MIT` file or <http://opensource.org/licenses/MIT>
+ * for more details.
+ */
 .wallop-slider {
   width: 100%;
 }

--- a/dist/WallopSlider.js
+++ b/dist/WallopSlider.js
@@ -5,6 +5,9 @@
 *
 * @author Pedro Duarte
 * @author http://pedroduarte.me
+*
+* @licence: http://opensource.org/licenses/MIT MIT
+* @source: https://github.com/peduarte/wallop-slider
 */
 
 //------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi, I see you followed up on issue #8 and stated that a license in `bower.json`. Please merge this PR that makes that choice explicit in the README file and in the code itself.

And please consider [CC0](http://creativecommons.org/publicdomain/zero/1.0/) for next projects, as it avoids the need to have a license file shipped around with each copy of `wallop-slider.js`. ;)
