### PR TITLE
Use visibility to hide element from pointer events

### DIFF
--- a/css/wallop--fade.css
+++ b/css/wallop--fade.css
@@ -30,20 +30,25 @@
 @-webkit-keyframes fadeOut {
   100% {
     opacity: 0;
+    visibility: hidden;
   }
 }
 @-moz-keyframes fadeOut {
   100% {
     opacity: 0;
+    visibility: hidden;
   }
 }
 @-ms-keyframes fadeOut {
   100% {
     opacity: 0;
+    visibility: hidden;
   }
 }
 @keyframes fadeOut {
   100% {
     opacity: 0;
+    visibility: hidden;
   }
 }
+


### PR DESCRIPTION
Re: https://css-tricks.com/snippets/css/toggle-visibility-when-hiding-elements/

Basically I used Wallop, it was awesome, but I couldn't select the content of the currently viewed item. I used `visibility: hidden` to hide the element. This means the user can interact with the currently viewed item but still allow the item to transition to the next item.

Fixes #56 and #54.