### PR TITLE
Fix slide CSS animation for safari browser

### DIFF
--- a/css/wallop--slide.css
+++ b/css/wallop--slide.css
@@ -43,184 +43,96 @@
 
 @-webkit-keyframes slideFromLeft {
   0% {
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @-moz-keyframes slideFromLeft {
   0% {
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @-ms-keyframes slideFromLeft {
   0% {
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @keyframes slideFromLeft {
   0% {
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @-webkit-keyframes slideFromRight {
   0% {
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @-moz-keyframes slideFromRight {
   0% {
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @-ms-keyframes slideFromRight {
   0% {
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @keyframes slideFromRight {
   0% {
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @-webkit-keyframes slideToLeft {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @-moz-keyframes slideToLeft {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @-ms-keyframes slideToLeft {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @keyframes slideToLeft {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(-100%, 0, 0);
-    -moz-transform: translate3d(-100%, 0, 0);
-    -ms-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: -100%;
   }
 }
 
 @-webkit-keyframes slideToRight {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @-moz-keyframes slideToRight {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @-ms-keyframes slideToRight {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }
 
 @keyframes slideToRight {
-  99% {
-    opacity: 1;
-  }
-
   100% {
-    opacity: 0;
-    -webkit-transform: translate3d(100%, 0, 0);
-    -moz-transform: translate3d(100%, 0, 0);
-    -ms-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
+    left: 100%;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallop",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "wallop is a minimal 4kb library for showing & hiding things",
   "main": "js/Wallop.js",
   "scripts": {


### PR DESCRIPTION
according to my created issue: https://github.com/peduarte/wallop/issues/88

wondering why the CSS animation was quite a bit complex with that 99% opacity and translate3d stuff... 🧐
I just did with that `left` property and it works well in Chrome, FF, IE11, Samsung Browsers.